### PR TITLE
Correct case of filename in #include directive

### DIFF
--- a/src/qdec.h
+++ b/src/qdec.h
@@ -26,7 +26,7 @@
 #ifndef __INC_SIMPLEHACKS_QDEC
 #define __INC_SIMPLEHACKS_QDEC
 
-#include <arduino.h>
+#include <Arduino.h>
 #include <stdint.h>
 
 #if defined(SIMPLEHACKS_QDECODER_NEVER_INLINE)


### PR DESCRIPTION
Incorrect capitalization of Arduino.h in `#include` directive causes compilation to fail on filename case-sensitive operating systems like Linux.